### PR TITLE
Fix dark mode detection for system theme for highlight unfolded comments

### DIFF
--- a/Highlight-Unfolded-Comments/StackHighlightUnfoldedComments.user.js
+++ b/Highlight-Unfolded-Comments/StackHighlightUnfoldedComments.user.js
@@ -57,7 +57,9 @@ const observeContainer = (commentsContainer) => {
         }
         for (const comment of newComments) {
             window.setTimeout(() => {
-                const highlightColor = document.body.matches('.theme-dark')
+                const highlightColor =
+                  document.body.matches('.theme-system') && window.matchMedia('(prefers-color-scheme: dark)').matches ||
+                  document.body.matches('.theme-dark')
                     ? '#403d33' // Dark brown, close to default dark background
                     : '#fff2e0'; // Pale yellow, close to default light background
                 // eslint-disable-next-line no-param-reassign

--- a/Highlight-Unfolded-Comments/StackHighlightUnfoldedComments.user.js
+++ b/Highlight-Unfolded-Comments/StackHighlightUnfoldedComments.user.js
@@ -3,7 +3,7 @@
 // @description      Keeps newly-unfolded comments highlighted, to easily distinguish them from higher-scoring comments you've already read
 // @author           CertainPerformance
 // @namespace        https://github.com/CertainPerformance/Stack-Exchange-Userscripts
-// @version          1.0.6
+// @version          1.0.7
 // @include          /^https://(?:[^/]+\.)?(?:(?:stackoverflow|serverfault|superuser|stackexchange|askubuntu|stackapps)\.com|mathoverflow\.net)/(?:questions/\d|review/\w(?!.*/stats|.*/history))/
 // @grant            none
 // ==/UserScript==


### PR DESCRIPTION
When the dark mode is set to ‘System setting’, the `theme-dark` class isn't present and instead `theme-system` is on the `body` element.

![Screenshot of HTML source of StackOverflow page, showing that the `theme-dark` class is not present on the `body` element. The body instead has a `theme-system` class which is referred to in the styles tab of the Chrome DevTools as `@media (prefers-color-scheme: dark) body.theme-system`.](https://user-images.githubusercontent.com/31467609/122201730-aff48a80-cedf-11eb-9bf6-758ae61175da.png)

This PR uses [`window.matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) if the body class is `theme-system` to detect if the `prefers-color-scheme` is `dark`.

Fixes #22